### PR TITLE
change marked comments to green color

### DIFF
--- a/fitak.cz/css/screen.css
+++ b/fitak.cz/css/screen.css
@@ -81,8 +81,8 @@ a[href^="error:"] {
 }
 
 .topic .comment-marked {
-    border-color: darkred;
-	box-shadow: -1px -1px 4px darkred;
+    border-color: darkgreen;
+	box-shadow: -1px -1px 4px darkgreen;
 }
 
 .highlight {


### PR DESCRIPTION
Pro vyznačení příspěvku se shodou hledaného výrazu je lepší mít pozitivní barvu (zelenou) než (zákazovou) červenou.
